### PR TITLE
GcpProject and projectId providers

### DIFF
--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpProject.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpProject.java
@@ -1,0 +1,20 @@
+package org.springframework.cloud.gcp.core.autoconfig;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author João André Martins
+ */
+@ConfigurationProperties("cloud.gcp.project")
+public class GcpProject {
+
+  private String id;
+
+  public String getId() {
+    return id;
+  }
+
+  public void setId(String id) {
+    this.id = id;
+  }
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpProjectAutoConfiguration.java
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/java/org/springframework/cloud/gcp/core/autoconfig/GcpProjectAutoConfiguration.java
@@ -1,0 +1,50 @@
+package org.springframework.cloud.gcp.core.autoconfig;
+
+import java.util.logging.Logger;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import com.google.common.base.Strings;
+
+/**
+ * @author João André Martins
+ */
+@Configuration
+@EnableConfigurationProperties(GcpProject.class)
+public class GcpProjectAutoConfiguration {
+
+  private static final Logger LOGGER =
+      Logger.getLogger(GcpProjectAutoConfiguration.class.getName());
+
+  private static final String PROJECT_ID_ENV_VAR_NAME = "GCP_PROJECT_ID";
+
+  private GcpProject gcpProjectFromProperties;
+
+  @Autowired
+  public GcpProjectAutoConfiguration(GcpProject gcpProjectFromProperties) {
+    this.gcpProjectFromProperties = gcpProjectFromProperties;
+  }
+
+  @Bean
+  public String gcpProjectId() {
+    String projectId = System.getProperty(PROJECT_ID_ENV_VAR_NAME);
+    if (!Strings.isNullOrEmpty(projectId)) {
+      LOGGER.info("Getting project ID from an environment variable.");
+      return projectId;
+    }
+
+    if (gcpProjectFromProperties != null) {
+      LOGGER.info("Getting project ID from the properties file.");
+      return gcpProjectFromProperties.getId();
+    }
+
+    // TODO(joaomartins): Try to get project ID in credentials.
+
+    // TODO(joaomartins): Try to get project ID from Metadata server.
+
+    return null;
+  }
+}

--- a/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/resources/META-INF/spring.factories
+++ b/spring-cloud-gcp-starters/spring-cloud-gcp-starter-core/src/main/resources/META-INF/spring.factories
@@ -1,2 +1,3 @@
 org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
-org.springframework.cloud.gcp.core.autoconfig.CredentialsAutoConfiguration
+org.springframework.cloud.gcp.core.autoconfig.CredentialsAutoConfiguration,\
+  org.springframework.cloud.gcp.core.autoconfig.GcpProjectAutoConfiguration


### PR DESCRIPTION
This would enable the following user experience:

```
  @Bean
  @ServiceActivator(inputChannel = "pubsubOutputChannel")
  public MessageHandler messageSender(@Qualifier("gcpProjectId") String projectId)
      throws IOException {
    return new PubSubMessageHandler(projectId, "test");
  }
```

However, it might be lacking stuff such as @ConditionalOnClass, we might want to rename GcpProject to GcpConfiguration, etc.
Seeking your feedback!

Fixes https://github.com/spring-cloud/spring-cloud-gcp/issues/13